### PR TITLE
Connect predictor to backend and add interactive hero background

### DIFF
--- a/frontend/app/api/forecast/route.js
+++ b/frontend/app/api/forecast/route.js
@@ -1,0 +1,15 @@
+export const dynamic = "force-dynamic";
+
+export async function GET(req) {
+  const { searchParams } = new URL(req.url);
+  const ticker = searchParams.get("ticker") ?? "AAPL";
+  const look_back = searchParams.get("look_back") ?? "60";
+  const horizon = searchParams.get("horizon") ?? "10";
+  const base = process.env.NEXT_PUBLIC_BACKEND_URL;
+  const url = `${base}/forecast?ticker=${encodeURIComponent(ticker)}&look_back=${look_back}&horizon=${horizon}`;
+  const res = await fetch(url, { cache: "no-store" });
+  return new Response(res.body, {
+    status: res.status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/frontend/app/components/PredictionPanel.jsx
+++ b/frontend/app/components/PredictionPanel.jsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+export default function PredictionPanel() {
+  const [ticker, setTicker] = useState("AAPL")
+  const [lookBack, setLookBack] = useState(60)
+  const [horizon, setHorizon] = useState(10)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [data, setData] = useState(null)
+
+  async function run() {
+    try {
+      setLoading(true)
+      setError(null)
+      setData(null)
+      const qs = new URLSearchParams({
+        ticker,
+        look_back: String(lookBack),
+        horizon: String(horizon),
+      })
+      const res = await fetch(`/api/forecast?${qs.toString()}`)
+      if (!res.ok) {
+        setError(`HTTP ${res.status}`)
+        return
+      }
+      const json = await res.json()
+      setData(json)
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const rows = data?.forecast?.slice(0, 10) ?? []
+
+  return (
+    <div className="max-w-3xl mx-auto my-6 space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
+        <Input
+          value={ticker}
+          onChange={(e) => setTicker(e.target.value)}
+          placeholder="Ticker e.g. AAPL or BTC-USD"
+        />
+        <Input
+          type="number"
+          value={lookBack}
+          onChange={(e) => setLookBack(parseInt(e.target.value || "60"))}
+        />
+        <Input
+          type="number"
+          value={horizon}
+          onChange={(e) => setHorizon(parseInt(e.target.value || "10"))}
+        />
+        <Button onClick={run} disabled={loading}>
+          Run AI Prediction
+        </Button>
+      </div>
+
+      {loading && <p>Loading…</p>}
+      {error && <p className="text-danger">{error}</p>}
+
+      {rows.length > 0 && (
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr>
+              <th className="text-left p-2">Date</th>
+              <th className="text-right p-2">Predicted Price</th>
+              <th className="text-right p-2">Predicted Return (%)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={i}>
+                <td className="p-2">
+                  {r?.date ? new Date(r.date).toLocaleDateString() : "-"}
+                </td>
+                <td className="p-2 text-right">
+                  {r?.pred_price !== null && r?.pred_price !== undefined
+                    ? Number(r.pred_price).toFixed(2)
+                    : "-"}
+                </td>
+                <td className="p-2 text-right">
+                  {r?.pred_return !== null && r?.pred_return !== undefined
+                    ? (Number(r.pred_return) * 100).toFixed(2) + "%"
+                    : "-"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/frontend/app/forecast/page.jsx
+++ b/frontend/app/forecast/page.jsx
@@ -1,0 +1,5 @@
+import PredictionPanel from "@/app/components/PredictionPanel"
+
+export default function ForecastPage() {
+  return <PredictionPanel />
+}

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -1,6 +1,6 @@
 "use client"
 
-import BackgroundFX from "@/components/ui/background-fx"
+import GalaxyInteractiveHeroBackground from "@/components/ui/galaxy-interactive-hero-background"
 import HomeHero from "@/components/home/home-hero"
 import KeyActions from "@/components/home/key-actions"
 import WhoUsesThis from "@/components/home/who-uses-this"
@@ -10,9 +10,9 @@ import Footer from "@/components/home/footer"
 export default function HomePage() {
   return (
     <div className="min-h-screen bg-background relative">
-      <BackgroundFX />
-
-      <HomeHero />
+      <GalaxyInteractiveHeroBackground>
+        <HomeHero />
+      </GalaxyInteractiveHeroBackground>
 
       <KeyActions />
 

--- a/frontend/components/ui/galaxy-interactive-hero-background.jsx
+++ b/frontend/components/ui/galaxy-interactive-hero-background.jsx
@@ -1,0 +1,29 @@
+"use client"
+
+import React, { lazy, Suspense } from "react"
+const Spline = lazy(() => import("@splinetool/react-spline"))
+
+export default function GalaxyInteractiveHeroBackground({ children }) {
+  return (
+    <div className="relative min-h-screen">
+      <div className="absolute inset-0 z-0 pointer-events-auto overflow-hidden">
+        <Suspense fallback={null}>
+          <Spline
+            style={{ width: "100%", height: "100vh", pointerEvents: "auto" }}
+            scene="https://prod.spline.design/us3ALejTXl6usHZ7/scene.splinecode"
+          />
+        </Suspense>
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            background: `\
+              linear-gradient(to right, rgba(0,0,0,0.8), transparent 30%, transparent 70%, rgba(0,0,0,0.8)),\
+              linear-gradient(to bottom, transparent 50%, rgba(0,0,0,0.9))
+            `,
+          }}
+        />
+      </div>
+      <div className="relative z-10">{children}</div>
+    </div>
+  )
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",
-    "zod": "3.25.67"
+    "zod": "3.25.67",
+    "@splinetool/react-spline": "latest"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.9",


### PR DESCRIPTION
## Summary
- proxy `/api/forecast` to backend using `NEXT_PUBLIC_BACKEND_URL`
- add JSX PredictionPanel that calls proxy and renders 10-row forecast table
- mount Spline-powered interactive hero background on homepage
- document dependency `@splinetool/react-spline`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(blocked by interactive prompt)*


------
https://chatgpt.com/codex/tasks/task_e_68a35314b22083328fe08e148f6a8190