### PR TITLE
Handle symbol fetch failures with timeout and offline cache docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # stock-predictor
+
+## Development
+
+When network access to the NASDAQ/NYSE symbol lists is restricted, the
+frontend can read cached copies of the data. Set the environment variables
+`NASDAQ_SYMBOLS_FILE` and `OTHERLISTED_SYMBOLS_FILE` to the paths of local
+`nasdaqtraded.txt` and `otherlisted.txt` files to enable this behavior.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,3 +28,15 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Local Symbol Cache
+
+When developing without external network access, you can point the app to
+cached copies of the NASDAQ and other listed symbol files. Set the following
+environment variables to the file paths of the downloaded CSV files:
+
+- `NASDAQ_SYMBOLS_FILE` – path to `nasdaqtraded.txt`
+- `OTHERLISTED_SYMBOLS_FILE` – path to `otherlisted.txt`
+
+When these variables are present, the API will read from the local files
+instead of fetching them from the internet.

--- a/frontend/app/api/symbols/search/route.js
+++ b/frontend/app/api/symbols/search/route.js
@@ -12,7 +12,17 @@ export async function GET(req) {
   }
   const limit = Math.min(parseInt(searchParams.get("limit") || "200", 10), 200);
   const cursor = parseInt(searchParams.get("cursor") || "0", 10);
-  const [us, crypto] = await Promise.all([getUsSymbols(), getCryptoSymbols()]);
+  let us;
+  try {
+    us = await getUsSymbols();
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Unable to load symbols" },
+      { status: 502 }
+    );
+  }
+  const crypto = await getCryptoSymbols();
   const data = [...us, ...crypto];
   const fuse = new Fuse(data, {
     keys: [

--- a/frontend/lib/symbols.js
+++ b/frontend/lib/symbols.js
@@ -1,43 +1,67 @@
-const NASDAQ_URL = "https://ftp.nasdaqtrader.com/dynamic/SymDir/nasdaqtraded.txt";
-const OTHER_URL = "https://ftp.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt";
-const COINGECKO_URL = "https://api.coingecko.com/api/v3/coins/list?include_platform=false";
+import { readFile } from "node:fs/promises";
+
+const NASDAQ_URL =
+  "https://ftp.nasdaqtrader.com/dynamic/SymDir/nasdaqtraded.txt";
+const OTHER_URL =
+  "https://ftp.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt";
+const COINGECKO_URL =
+  "https://api.coingecko.com/api/v3/coins/list?include_platform=false";
+
+const NASDAQ_FILE = process.env.NASDAQ_SYMBOLS_FILE;
+const OTHER_FILE = process.env.OTHERLISTED_SYMBOLS_FILE;
+const FETCH_TIMEOUT = 5000;
+
+async function loadText(url, file) {
+  if (file) {
+    return readFile(file, "utf8");
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    return await res.text();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 async function getUsSymbols() {
   if (globalThis.__usSymbols) return globalThis.__usSymbols;
-  const [nasdaqRes, otherRes] = await Promise.all([
-    fetch(NASDAQ_URL),
-    fetch(OTHER_URL),
-  ]);
-  const [nasdaqTxt, otherTxt] = await Promise.all([
-    nasdaqRes.text(),
-    otherRes.text(),
-  ]);
-  const map = new Map();
-  const parseNasdaq = () => {
-    const lines = nasdaqTxt.trim().split("\n").slice(1);
-    for (const line of lines) {
-      const [symbol, name, , test, , , etf] = line.split("|");
-      if (!symbol || test === "Y") continue;
-      const type = etf === "Y" ? "etf" : "stock";
-      map.set(symbol, { symbol, name, exchange: "NASDAQ", type });
-    }
-  };
-  const parseOther = () => {
-    const lines = otherTxt.trim().split("\n").slice(1);
-    for (const line of lines) {
-      const [symbol, name, exchange, , etf, , test] = line.split("|");
-      if (!symbol || test === "Y") continue;
-      const type = etf === "Y" ? "etf" : "stock";
-      if (!map.has(symbol)) {
-        map.set(symbol, { symbol, name, exchange, type });
+  try {
+    const [nasdaqTxt, otherTxt] = await Promise.all([
+      loadText(NASDAQ_URL, NASDAQ_FILE),
+      loadText(OTHER_URL, OTHER_FILE),
+    ]);
+    const map = new Map();
+    const parseNasdaq = () => {
+      const lines = nasdaqTxt.trim().split("\n").slice(1);
+      for (const line of lines) {
+        const [symbol, name, , test, , , etf] = line.split("|");
+        if (!symbol || test === "Y") continue;
+        const type = etf === "Y" ? "etf" : "stock";
+        map.set(symbol, { symbol, name, exchange: "NASDAQ", type });
       }
-    }
-  };
-  parseNasdaq();
-  parseOther();
-  const arr = Array.from(map.values());
-  globalThis.__usSymbols = arr;
-  return arr;
+    };
+    const parseOther = () => {
+      const lines = otherTxt.trim().split("\n").slice(1);
+      for (const line of lines) {
+        const [symbol, name, exchange, , etf, , test] = line.split("|");
+        if (!symbol || test === "Y") continue;
+        const type = etf === "Y" ? "etf" : "stock";
+        if (!map.has(symbol)) {
+          map.set(symbol, { symbol, name, exchange, type });
+        }
+      }
+    };
+    parseNasdaq();
+    parseOther();
+    const arr = Array.from(map.values());
+    globalThis.__usSymbols = arr;
+    return arr;
+  } catch (err) {
+    console.error("Failed to fetch US symbols", err);
+    throw new Error("US_SYMBOLS_UNAVAILABLE");
+  }
 }
 
 async function getCryptoSymbols() {


### PR DESCRIPTION
## Summary
- Protect US symbol retrieval with AbortController timeout, optional local CSV fallbacks and error handling
- Return HTTP 502 with JSON error when symbol loading fails
- Document environment variables for supplying cached NASDAQ/NYSE files during restricted development

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a43716a2088332af422571c0a70cb3