### PR TITLE
Add US symbols fetch timeout and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@
 
 ## Development
 
-When network access to the NASDAQ/NYSE symbol lists is restricted, the
-frontend can read cached copies of the data. Set the environment variables
+When outbound requests to the NASDAQ/NYSE symbol lists are blocked, the frontend
+can fall back to cached copies of the CSV data. Set the environment variables
 `NASDAQ_SYMBOLS_FILE` and `OTHERLISTED_SYMBOLS_FILE` to the paths of local
-`nasdaqtraded.txt` and `otherlisted.txt` files to enable this behavior.
+`nasdaqtraded.txt` and `otherlisted.txt` files:
+
+```
+export NASDAQ_SYMBOLS_FILE=/path/to/nasdaqtraded.txt
+export OTHERLISTED_SYMBOLS_FILE=/path/to/otherlisted.txt
+```
+
+If the network requires a proxy for outbound HTTP requests, configure standard
+proxy environment variables before running the frontend:
+
+```
+export HTTPS_PROXY=http://proxy.example.com:8080
+export HTTP_PROXY=http://proxy.example.com:8080
+```

--- a/frontend/app/api/symbols/search/route.js
+++ b/frontend/app/api/symbols/search/route.js
@@ -16,11 +16,13 @@ export async function GET(req) {
   try {
     us = await getUsSymbols();
   } catch (err) {
-    console.error(err);
-    return NextResponse.json(
-      { error: "Unable to load symbols" },
-      { status: 502 }
-    );
+    if (err?.message === "US_SYMBOLS_UNAVAILABLE") {
+      return NextResponse.json(
+        { error: "Unable to load US symbols" },
+        { status: 502 }
+      );
+    }
+    throw err;
   }
   const crypto = await getCryptoSymbols();
   const data = [...us, ...crypto];

--- a/frontend/app/api/symbols/us/route.js
+++ b/frontend/app/api/symbols/us/route.js
@@ -9,6 +9,12 @@ export async function GET() {
     const headers = { "Cache-Control": "s-maxage=3600, stale-while-revalidate=86400" };
     return NextResponse.json({ items }, { headers });
   } catch (e) {
-    return NextResponse.json({ error: "Failed to load symbols" }, { status: 500 });
+    if (e?.message === "US_SYMBOLS_UNAVAILABLE") {
+      return NextResponse.json(
+        { error: "Unable to load US symbols" },
+        { status: 502 }
+      );
+    }
+    throw e;
   }
 }


### PR DESCRIPTION
## Summary
- add `loadText` helper with timeout and local CSV fallback for US symbol lists
- return HTTP 502 from symbol APIs when US symbols are unavailable
- document local CSV fallbacks and proxy configuration in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint config, unable to run)
- `npm run build` (fails to fetch Google Fonts due to network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68a43b24ee008332b43a9d4cafe62059