### PR TITLE
fix overview API and add fastapi proxy

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/frontend/app/t/[ticker]/page.jsx
+++ b/frontend/app/t/[ticker]/page.jsx
@@ -1,15 +1,23 @@
-"use client"
+"use client";
 
-import { useState } from 'react'
-import { useParams } from 'next/navigation'
-import { AnimatedTabs } from '@/components/stock/animated-tabs'
-import HeaderPrice from '@/components/stock/HeaderPrice'
-import KpiRow from '@/components/stock/KpiRow'
-import PriceChart from '@/components/stock/PriceChart'
-import LatestHeadlines from '@/components/stock/LatestHeadlines'
-import PredictionPanel from '@/components/stock/prediction-panel'
-import BacktestPanel from '@/components/stock/backtest-panel'
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { useState, Suspense } from "react";
+import dynamic from "next/dynamic";
+import { useParams } from "next/navigation";
+import { AnimatedTabs } from "@/components/stock/animated-tabs";
+import HeaderPrice from "@/components/stock/HeaderPrice";
+import KpiRow from "@/components/stock/KpiRow";
+import PriceChart from "@/components/stock/PriceChart";
+import LatestHeadlines from "@/components/stock/LatestHeadlines";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+const PredictionPanel = dynamic(
+  () => import("@/components/stock/prediction-panel").then((m) => m.PredictionPanel),
+  { ssr: false }
+);
+const BacktestPanel = dynamic(
+  () => import("@/components/stock/backtest-panel").then((m) => m.BacktestPanel),
+  { ssr: false }
+);
 
 export default function TickerPage() {
   const params = useParams()
@@ -71,9 +79,23 @@ export default function TickerPage() {
 
             {activeTab === 'news' && <LatestHeadlines ticker={ticker} limit={8} />}
 
-            {activeTab === 'predictions' && <PredictionPanel ticker={ticker} />}
+            {activeTab === 'predictions' && (
+              <Suspense
+                fallback={
+                  <div className="text-sm opacity-70">
+                    Running prediction… this can take a few minutes.
+                  </div>
+                }
+              >
+                <PredictionPanel ticker={ticker} />
+              </Suspense>
+            )}
 
-            {activeTab === 'backtest' && <BacktestPanel ticker={ticker} />}
+            {activeTab === 'backtest' && (
+              <Suspense fallback={<div className="text-sm opacity-70">Loading backtest…</div>}>
+                <BacktestPanel ticker={ticker} />
+              </Suspense>
+            )}
 
             {activeTab === 'filings' && (
               <Card>

--- a/frontend/components/stock/HeaderPrice.jsx
+++ b/frontend/components/stock/HeaderPrice.jsx
@@ -1,53 +1,37 @@
-"use client"
+"use client";
 
-import useSWR from 'swr'
-import { ArrowUp, ArrowDown } from 'lucide-react'
-import { Skeleton } from '@/components/ui/skeleton'
-import { fmtPrice } from '@/lib/format'
-import { useEffect } from 'react'
-import { toast } from 'sonner'
-
-const fetcher = (url) =>
-  fetch(url).then((r) => {
-    if (!r.ok) throw new Error('Network error')
-    return r.json()
-  })
+import { ArrowUp, ArrowDown } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fmtPrice } from "@/lib/format";
+import { useOverview } from "@/hooks/use-overview";
 
 export default function HeaderPrice({ ticker }) {
-  const { data, error, isLoading, mutate } = useSWR(
-    ticker ? `/api/overview/${ticker}` : null,
-    fetcher,
-    { dedupingInterval: 30000, keepPreviousData: true }
-  )
+  const { data, err, loading, reload } = useOverview(ticker);
 
-  useEffect(() => {
-    if (error) toast.error('Failed to load price')
-  }, [error])
-
-  if (isLoading) {
-    return <Skeleton className="h-12 w-full" />
+  if (loading) {
+    return <Skeleton className="h-12 w-full" />;
   }
 
-  if (error) {
+  if (err) {
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground" role="alert">
         <span>Failed to load price data.</span>
-        <button onClick={() => mutate()} className="underline">
+        <button onClick={() => reload()} className="underline">
           Retry
         </button>
       </div>
-    )
+    );
   }
 
-  const { price, change, changePercent, currency, regularMarketTime } = data || {}
+  const { price, change, changePercent, currency, asOf } = data || {};
   const pos = (change ?? 0) > 0
   const neg = (change ?? 0) < 0
   const color = pos ? 'text-green-600' : neg ? 'text-red-600' : 'text-foreground'
   const arrow = pos ? <ArrowUp className="h-4 w-4" /> : neg ? <ArrowDown className="h-4 w-4" /> : null
   const absChange = Math.abs(change ?? 0).toFixed(2)
   const absPct = Math.abs(changePercent ?? 0).toFixed(2)
-  const timeStr = regularMarketTime
-    ? new Date(regularMarketTime * 1000).toLocaleTimeString('en-US', {
+  const timeStr = asOf
+    ? new Date(asOf * 1000).toLocaleTimeString('en-US', {
         hour: 'numeric',
         minute: '2-digit',
         timeZone: 'America/New_York',
@@ -64,9 +48,7 @@ export default function HeaderPrice({ ticker }) {
           {absChange} ({absPct}%)
         </span>
       </div>
-      {timeStr && (
-        <div className="text-xs text-muted-foreground">As of {timeStr}</div>
-      )}
+      {timeStr && <div className="text-xs text-muted-foreground">As of {timeStr}</div>}
     </div>
   )
 }

--- a/frontend/components/stock/PriceChart.jsx
+++ b/frontend/components/stock/PriceChart.jsx
@@ -1,8 +1,8 @@
-"use client"
+"use client";
 
-import useSWR from "swr"
-import { useTheme } from "next-themes"
-import { useReducedMotion } from "framer-motion"
+import useSWR from "swr";
+import { useTheme } from "next-themes";
+import { useReducedMotion } from "framer-motion";
 import {
   ResponsiveContainer,
   AreaChart,
@@ -12,22 +12,23 @@ import {
   CartesianGrid,
   Tooltip,
   ReferenceDot,
-} from "recharts"
+} from "recharts";
+import { API } from "@/lib/api";
 
-const fetcher = (url) =>
-  fetch(url).then((r) => {
-    if (!r.ok) throw new Error("Network error")
-    return r.json()
-  })
+const fetcher = (path) =>
+  API(path).then((r) => {
+    if (!r.ok) throw new Error("Network error");
+    return r.json();
+  });
 
 export default function PriceChart({ ticker }) {
-  const { theme } = useTheme()
-  const reduceMotion = useReducedMotion()
+  const { theme } = useTheme();
+  const reduceMotion = useReducedMotion();
   const { data, error, isLoading, mutate } = useSWR(
-    ticker ? `/api/chart/${ticker}?range=1y&interval=1d` : null,
+    ticker ? `/chart/${ticker}?range=1y&interval=1d` : null,
     fetcher,
     { dedupingInterval: 30000, keepPreviousData: true }
-  )
+  );
 
   if (isLoading) {
     return (
@@ -55,7 +56,7 @@ export default function PriceChart({ ticker }) {
     )
   }
 
-  const series = data?.series ?? []
+  const series = data?.series ?? [];
   if (series.length === 0) {
     return (
       <div className="h-80 w-full rounded-md border border-border flex items-center justify-center text-sm text-muted-foreground">
@@ -63,7 +64,7 @@ export default function PriceChart({ ticker }) {
       </div>
     )
   }
-  const prices = series.map((p) => p.c)
+  const prices = series.map((p) => p.close)
   const min = Math.min(...prices)
   const max = Math.max(...prices)
   const pad = (max - min) * 0.02
@@ -98,7 +99,7 @@ export default function PriceChart({ ticker }) {
             vertical={false}
           />
           <XAxis
-            dataKey="t"
+            dataKey="date"
             tickFormatter={formatX}
             stroke="hsl(var(--muted-foreground))"
             tick={{ fontSize: 12 }}
@@ -123,7 +124,7 @@ export default function PriceChart({ ticker }) {
           />
           <Area
             type="monotone"
-            dataKey="c"
+            dataKey="close"
             stroke="hsl(var(--primary))"
             fill="hsl(var(--primary) / 0.2)"
             strokeWidth={2}
@@ -133,8 +134,8 @@ export default function PriceChart({ ticker }) {
           />
           {last && (
             <ReferenceDot
-              x={last.t}
-              y={last.c}
+              x={last.date}
+              y={last.close}
               r={4}
               fill="hsl(var(--primary))"
               stroke="hsl(var(--background))"

--- a/frontend/components/stock/backtest-panel.jsx
+++ b/frontend/components/stock/backtest-panel.jsx
@@ -1,8 +1,9 @@
-"use client"
+"use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { StatCard } from "./stat-card"
-import { TrendingUp, BarChart3 } from "lucide-react"
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { StatCard } from "./stat-card";
+import { TrendingUp, BarChart3 } from "lucide-react";
 
 export function BacktestPanel({ ticker }) {
   const backtestResults = {

--- a/frontend/components/stock/prediction-panel.jsx
+++ b/frontend/components/stock/prediction-panel.jsx
@@ -1,6 +1,6 @@
-"use client"
+"use client";
 
-import { useState, useMemo } from "react"
+import React, { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"

--- a/frontend/hooks/use-overview.js
+++ b/frontend/hooks/use-overview.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { API } from "@/lib/api";
+
+export function useOverview(ticker) {
+  const [data, setData] = useState(null);
+  const [err, setErr] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await API(`/overview/${ticker}`);
+      if (!res.ok) throw new Error("overview request failed");
+      setData(await res.json());
+    } catch (e) {
+      setErr(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (ticker) load();
+  }, [ticker]);
+
+  return { data, err, loading, reload: load };
+}

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -18,7 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["*"]
     }
   },
   "include": ["**/*.js", "**/*.jsx", ".next/types/**/*.ts"],

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,0 +1,5 @@
+export const API = (path, init) =>
+  fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${path}`, {
+    ...init,
+    cache: "no-store",
+  });


### PR DESCRIPTION
## Summary
- fix dynamic imports for prediction and backtest panels with loading fallbacks
- expose stock overview via yahoo-finance2 and proxy to backend
- add FastAPI endpoints for overview and chart

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive setup)*
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4bbe661408332aef93d79ab97c7b2