### PR TITLE
Improve overview API and prediction panel

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -73,26 +73,56 @@ def forecast(
 def overview(ticker: str):
     try:
         t = yf.Ticker(ticker.upper())
-        fi = t.fast_info
-        price = float(fi.get("last_price") or fi.get("last_close") or 0)
-        day_low = fi.get("day_low"); day_high = fi.get("day_high")
-        volume = fi.get("last_volume"); market_cap = fi.get("market_cap")
-        currency = fi.get("currency")
+        fi = getattr(t, "fast_info", {}) or {}
+
+        price = fi.get("last_price") or fi.get("last_close") or fi.get("regular_market_price")
+        prev = fi.get("previous_close") or fi.get("last_close")
+        day_low = fi.get("day_low")
+        day_high = fi.get("day_high")
+        volume = fi.get("last_volume") or fi.get("regular_market_volume")
+        market_cap = fi.get("market_cap")
+        currency = fi.get("currency") or "USD"
         pe_ratio = None
+
+        if not price or price == 0:
+            hist = t.history(period="2d", interval="1d")
+            if not hist.empty:
+                price = float(hist["Close"].iloc[-1])
+                if len(hist) > 1:
+                    prev = float(hist["Close"].iloc[-2])
+
+        if day_low is None or day_high is None:
+            intraday = t.history(period="1d", interval="1m")
+            if not intraday.empty:
+                day_low = float(intraday["Low"].min())
+                day_high = float(intraday["High"].max())
+
         try:
             info = t.info or {}
-            pe_ratio = info.get("trailingPE")
+            pe_ratio = info.get("trailingPE", pe_ratio)
+            market_cap = market_cap or info.get("marketCap")
         except Exception:
             pass
+
+        change = None
+        change_pct = None
+        if price is not None and prev is not None:
+            change = float(price) - float(prev)
+            if prev:
+                change_pct = change / float(prev)
+
         return {
             "ticker": ticker.upper(),
-            "price": price,
-            "change": None,
-            "changePercent": None,
-            "volume": volume,
-            "peRatio": pe_ratio,
-            "marketCap": market_cap,
-            "dayRange": {"low": day_low, "high": day_high},
+            "price": float(price or 0),
+            "change": change,
+            "changePercent": change_pct,
+            "volume": int(volume) if volume is not None else None,
+            "peRatio": float(pe_ratio) if pe_ratio is not None else None,
+            "marketCap": int(market_cap) if market_cap is not None else None,
+            "dayRange": {
+                "low": float(day_low) if day_low is not None else None,
+                "high": float(day_high) if day_high is not None else None,
+            },
             "currency": currency,
         }
     except Exception as e:

--- a/frontend/app/t/[ticker]/page.jsx
+++ b/frontend/app/t/[ticker]/page.jsx
@@ -5,7 +5,7 @@ import dynamic from "next/dynamic";
 import { useParams } from "next/navigation";
 import { AnimatedTabs } from "@/components/stock/animated-tabs";
 import HeaderPrice from "@/components/stock/HeaderPrice";
-import KpiRow from "@/components/stock/KpiRow";
+import { OverviewSection } from "@/components/stock/overview-section";
 import PriceChart from "@/components/stock/PriceChart";
 import LatestHeadlines from "@/components/stock/LatestHeadlines";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -60,7 +60,7 @@ export default function TickerPage() {
               <div className="space-y-6">
                 <Card>
                   <CardContent className="p-4">
-                    <KpiRow ticker={ticker} />
+                    <OverviewSection ticker={ticker} />
                   </CardContent>
                 </Card>
 

--- a/frontend/components/stock/HeaderPrice.jsx
+++ b/frontend/components/stock/HeaderPrice.jsx
@@ -1,54 +1,28 @@
-"use client";
+"use client"
 
-import { ArrowUp, ArrowDown } from "lucide-react";
-import { Skeleton } from "@/components/ui/skeleton";
-import { fmtPrice } from "@/lib/format";
-import { useOverview } from "@/hooks/use-overview";
+import { useOverview } from "@/hooks/use-overview"
+import { Skeleton } from "@/components/ui/skeleton"
 
 export default function HeaderPrice({ ticker }) {
-  const { data, err, loading, reload } = useOverview(ticker);
+  const { data, err, loading, reload } = useOverview(ticker)
 
-  if (loading) {
-    return <Skeleton className="h-12 w-full" />;
-  }
-
-  if (err) {
+  if (loading) return <Skeleton className="h-10 w-32" />
+  if (err)
     return (
-      <div className="flex items-center gap-2 text-sm text-muted-foreground" role="alert">
-        <span>Failed to load price data.</span>
-        <button onClick={() => reload()} className="underline">
-          Retry
-        </button>
+      <div className="text-sm text-red-500">
+        Failed to load. <button className="underline" onClick={reload}>Retry</button>
       </div>
-    );
-  }
+    )
 
-  const { price, change, changePercent, currency, asOf } = data || {};
-  const pos = (change ?? 0) > 0
-  const neg = (change ?? 0) < 0
-  const color = pos ? 'text-green-600' : neg ? 'text-red-600' : 'text-foreground'
-  const arrow = pos ? <ArrowUp className="h-4 w-4" /> : neg ? <ArrowDown className="h-4 w-4" /> : null
-  const absChange = Math.abs(change ?? 0).toFixed(2)
-  const absPct = Math.abs(changePercent ?? 0).toFixed(2)
-  const timeStr = asOf
-    ? new Date(asOf * 1000).toLocaleTimeString('en-US', {
-        hour: 'numeric',
-        minute: '2-digit',
-        timeZone: 'America/New_York',
-        timeZoneName: 'short',
-      })
-    : ''
+  const { price, changePercent } = data || {}
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-baseline gap-3">
-        <span className="text-4xl font-bold tracking-tight">{fmtPrice(price, currency)}</span>
-        <span className={`flex items-center text-sm ${color}`}>
-          {arrow}
-          {absChange} ({absPct}%)
-        </span>
-      </div>
-      {timeStr && <div className="text-xs text-muted-foreground">As of {timeStr}</div>}
+    <div className="text-4xl font-semibold text-zinc-900 dark:text-zinc-100">
+      {price ? price.toFixed(2) : "—"}
+      <span className="ml-3 text-base font-normal text-zinc-500 dark:text-zinc-400">
+        {changePercent != null ? `${(changePercent * 100).toFixed(2)}%` : "—"}
+      </span>
     </div>
   )
 }
+

--- a/frontend/components/stock/overview-section.jsx
+++ b/frontend/components/stock/overview-section.jsx
@@ -1,0 +1,59 @@
+"use client"
+import { useEffect, useState } from "react"
+import { API } from "@/lib/api"
+import { StatCard } from "@/components/ui/stat-card"
+
+export function OverviewSection({ ticker }) {
+  const [data, setData] = useState(null)
+  const [err, setErr] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  async function load() {
+    setLoading(true)
+    setErr(null)
+    try {
+      const r = await API(`/overview/${ticker}`)
+      if (!r.ok) throw new Error("overview failed")
+      setData(await r.json())
+    } catch (e) {
+      setErr(e)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (ticker) load()
+  }, [ticker])
+
+  if (loading) return <div className="text-sm opacity-70">Loading quote…</div>
+  if (err)
+    return (
+      <div className="text-sm text-red-500">
+        Failed to load. <button className="underline" onClick={load}>Retry</button>
+      </div>
+    )
+  if (!data) return null
+
+  const { price, changePercent, volume, peRatio, dayRange, marketCap, currency } = data
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard label="Price" value={`${price?.toFixed?.(2) ?? "—"} ${currency ?? ""}`} />
+      <StatCard
+        label="Market Cap"
+        value={marketCap ? Intl.NumberFormat("en", { notation: "compact" }).format(marketCap) : "—"}
+      />
+      <StatCard label="P/E Ratio" value={peRatio ?? "—"} />
+      <StatCard
+        label="Day Range"
+        value={
+          dayRange?.low && dayRange?.high
+            ? `${dayRange.low.toFixed(2)} - ${dayRange.high.toFixed(2)}`
+            : "—"
+        }
+      />
+    </div>
+  )
+}
+

--- a/frontend/components/stock/prediction-panel.jsx
+++ b/frontend/components/stock/prediction-panel.jsx
@@ -1,100 +1,36 @@
-"use client";
-
-import React, { useState, useMemo } from "react";
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { usePredictionJob, usePredictionStore } from "./prediction-store"
+"use client"
+import { useEffect } from "react"
+import { usePrediction } from "./prediction-store"
 import PredictionChart from "./PredictionChart"
-import { fmtPrice } from "@/lib/format"
 
 export function PredictionPanel({ ticker }) {
-  const { startJob } = usePredictionStore()
-  const job = usePredictionJob(ticker)
-  const [lookBack] = useState(60)
-  const [horizon] = useState(10)
+  const { active, error, forecast, run } = usePrediction()
 
-  async function run() {
-    const qs = new URLSearchParams({
-      ticker,
-      look_back: String(lookBack),
-      horizon: String(horizon),
-    })
-    const res = await fetch(`/api/forecast?${qs.toString()}`, { method: "POST" })
-    if (!res.ok) return
-    const json = await res.json()
-    startJob(ticker, json.jobId)
-  }
+  useEffect(() => {
+    if (ticker) run(ticker)
+  }, [ticker])
 
-  const forecast = job?.result?.forecast || []
-  const nextPrice = forecast.length ? forecast[forecast.length - 1].pred_price : null
-  const trend = useMemo(() => {
-    if (forecast.length < 2) return "—"
-    const last = forecast[forecast.length - 1].pred_price
-    const prev = forecast[forecast.length - 2].pred_price
-    if (last > prev) return "Uptrend"
-    if (last < prev) return "Downtrend"
-    return "—"
-  }, [forecast])
-  const confidence = useMemo(() => {
-    const cov = job?.result?.metrics?.coverage
-    if (typeof cov === "number") {
-      return Math.min(Math.max(Math.round(cov * 100), 0), 99)
-    }
-    return null
-  }, [job])
+  if (error)
+    return (
+      <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-red-200">
+        {error} <button className="ml-2 underline" onClick={() => run(ticker)}>Retry</button>
+      </div>
+    )
 
-  return (
-    <Card className="bg-card border-grid relative overflow-hidden">
-      {job && job.state !== "done" && (
-        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm z-10 flex flex-col items-center justify-center" aria-busy="true">
-          <p className="mb-4 text-foreground">Crunching the numbers… {Math.floor(job.pct || 0)}%</p>
-          {job.etaSeconds != null && (
-            <p className="text-sm text-muted-foreground mb-4">~{String(Math.floor(job.etaSeconds / 60)).padStart(1, "0")}:{String(job.etaSeconds % 60).padStart(2, "0")} remaining</p>
-          )}
-          <div className="w-64 bg-primary/20 rounded-full h-2 overflow-hidden">
-            <div className="bg-primary h-full" style={{ width: `${job.pct || 0}%` }} />
+  if (active && active.ticker === ticker)
+    return (
+      <div className="flex h-64 items-center justify-center rounded-xl border border-zinc-800/50 bg-zinc-900/30 p-6 text-zinc-300">
+        <div className="w-full max-w-md">
+          <div className="mb-2 text-center text-sm">Crunching the numbers… this may take a few minutes.</div>
+          <div className="h-2 w-full rounded-full bg-zinc-700/50">
+            <div className="h-2 w-1/3 animate-pulse rounded-full bg-blue-500/70" />
           </div>
         </div>
-      )}
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-foreground">AI Prediction Model</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4" aria-live="polite" aria-busy={job && job.state !== "done"}>
-        <Button onClick={run} disabled={job && job.state === "running"} className="w-full">
-          Run AI Prediction
-        </Button>
-        {forecast.length > 0 ? (
-          <PredictionChart data={forecast} />
-        ) : (
-          <div className="h-72 flex items-center justify-center text-muted-foreground">
-            <p>No forecast yet</p>
-          </div>
-        )}
-        {nextPrice != null && (
-          <div className="flex gap-4 justify-center">
-            <div className="text-center">
-              <div className="text-sm text-muted-foreground mb-1">Next Price</div>
-              <div className="text-2xl font-bold font-mono text-success">
-                {fmtPrice(nextPrice)}
-              </div>
-            </div>
-            {confidence != null && (
-              <div className="text-center">
-                <div className="text-sm text-muted-foreground mb-1">Confidence</div>
-                <div className="text-2xl font-bold font-mono text-primary">{confidence}%</div>
-              </div>
-            )}
-          </div>
-        )}
-        {trend !== "—" && (
-          <div className="flex justify-center">
-            <Badge variant="outline" className="bg-primary/20 text-primary border-primary/30">
-              {trend}
-            </Badge>
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  )
+      </div>
+    )
+
+  if (!forecast) return null
+
+  return <PredictionChart data={forecast} />
 }
+

--- a/frontend/components/ui/galaxy-interactive-hero-background.jsx
+++ b/frontend/components/ui/galaxy-interactive-hero-background.jsx
@@ -1,14 +1,18 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import Spline from "@splinetool/react-spline/next"
+import dynamic from "next/dynamic"
+
+const Spline = dynamic(() => import("@splinetool/react-spline/next"), { ssr: false })
 
 export default function GalaxyInteractiveHeroBackground({ children, scene }) {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const [prefersReducedMotion, setPRM] = useState(false)
 
   useEffect(() => {
+    setMounted(true)
     const media = window.matchMedia("(prefers-reduced-motion: reduce)")
-    const update = () => setPrefersReducedMotion(media.matches)
+    const update = () => setPRM(media.matches)
     update()
     media.addEventListener("change", update)
     return () => media.removeEventListener("change", update)
@@ -16,10 +20,9 @@ export default function GalaxyInteractiveHeroBackground({ children, scene }) {
 
   return (
     <div className="relative min-h-[100dvh]">
-      {prefersReducedMotion ? (
-        <div
-          className="absolute inset-0 -z-10 bg-gradient-to-b from-white via-slate-100 to-slate-200 dark:from-zinc-900 dark:via-zinc-950 dark:to-black"
-        />
+      {/* Fallback background to avoid fetch during render */}
+      {!mounted || prefersReducedMotion ? (
+        <div className="absolute inset-0 -z-10 bg-gradient-to-b from-white via-slate-100 to-slate-200 dark:from-zinc-900 dark:via-zinc-950 dark:to-black" />
       ) : (
         <div className="absolute inset-0 -z-10">
           <Spline

--- a/frontend/components/ui/input.jsx
+++ b/frontend/components/ui/input.jsx
@@ -1,16 +1,10 @@
-import * as React from "react"
-
 import { cn } from "@/lib/utils"
 
-function Input({ className, type, ...props }) {
+export function Input({ className, ...props }) {
   return (
     <input
-      type={type}
-      data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "w-full rounded-xl border border-zinc-300 bg-white px-3 py-2 text-zinc-900 placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder-zinc-400",
         className
       )}
       {...props}
@@ -18,4 +12,3 @@ function Input({ className, type, ...props }) {
   )
 }
 
-export { Input }

--- a/frontend/components/ui/stat-card.jsx
+++ b/frontend/components/ui/stat-card.jsx
@@ -1,0 +1,16 @@
+export function StatCard({ label, value, help }) {
+  return (
+    <div className="rounded-2xl border border-zinc-200/60 bg-white p-4 dark:border-zinc-800/60 dark:bg-zinc-900">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-600 dark:text-zinc-400">
+        {label}
+      </div>
+      <div className="mt-1 text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+        {value}
+      </div>
+      {help ? (
+        <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{help}</div>
+      ) : null}
+    </div>
+  )
+}
+

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,5 +1,2 @@
 export const API = (path, init) =>
-  fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${path}`, {
-    ...init,
-    cache: "no-store",
-  });
+  fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${path}`, { cache: "no-store", ...init })


### PR DESCRIPTION
## Summary
- lazy-load Spline hero with gradient fallback
- add robust FastAPI `/overview` endpoint
- add dark-mode StatCard and input styles; render new OverviewSection
- race-proof prediction runner with friendly progress message

## Testing
- `python -m py_compile backend/app.py`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c63245ec83329431a23018c2562a