### PR TITLE
fix: update Spline import for galaxy background

### DIFF
--- a/frontend/components/ui/galaxy-interactive-hero-background.jsx
+++ b/frontend/components/ui/galaxy-interactive-hero-background.jsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react"
 import dynamic from "next/dynamic"
 
-const Spline = dynamic(() => import("@splinetool/react-spline/next"), { ssr: false })
+const Spline = dynamic(() => import("@splinetool/react-spline"), { ssr: false })
 
 export default function GalaxyInteractiveHeroBackground({ children, scene }) {
   const [mounted, setMounted] = useState(false)


### PR DESCRIPTION
## Summary
- replace @splinetool/react-spline/next dynamic import with @splinetool/react-spline
- ensure galaxy background still lazy-loads client-side with gradient fallback

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ca015a1c8332af47ccd9a61d40f3