### PR TITLE
feat: add news endpoint and panel

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,11 +1,45 @@
 # app.py
-import os, json, tempfile, asyncio, uuid
+import os, json, tempfile, asyncio, uuid, re, time
 import papermill as pm
+import requests, feedparser
 import yfinance as yf
+from urllib.parse import quote_plus, urlparse, parse_qs
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
+
+HF_TOKEN = os.getenv("HF_TOKEN")  # put your HF token in backend env
+
+
+def _unwrap_google_news(url: str) -> str:
+    qs = parse_qs(urlparse(url).query)
+    return qs.get("url", [url])[0]
+
+
+def _label_from_scores(scores):
+    # scores is list of {label: '1 star'...'5 stars', score: float}
+    best = max(scores, key=lambda x: x["score"])
+    m = re.search(r"([1-5])", best["label"])
+    stars = int(m.group(1)) if m else 3
+    sentiment = "positive" if stars >= 4 else "negative" if stars <= 2 else "neutral"
+    return {"sentiment": sentiment, "stars": stars, "confidence": float(best["score"])}
+
+
+def classify_texts_via_api(texts: list[str]) -> list[dict]:
+    # If no token, fallback to neutral
+    if not HF_TOKEN:
+        return [{"sentiment": "neutral", "stars": 3, "confidence": 0.0} for _ in texts]
+    url = "https://api-inference.huggingface.co/models/tabularisai/multilingual-sentiment-analysis"
+    headers = {"Authorization": f"Bearer {HF_TOKEN}"}
+    out = []
+    for t in texts:
+        r = requests.post(url, headers=headers, json={"inputs": t, "options": {"wait_for_model": True}})
+        r.raise_for_status()
+        scores = r.json()[0]
+        out.append(_label_from_scores(scores))
+    return out
+
 
 NOTEBOOK_PATH = os.getenv("NOTEBOOK_PATH", "notebooks/Stock_LSTM_10day.ipynb")
 
@@ -232,6 +266,74 @@ def chart(ticker: str, range: str = Query("1y"), interval: str = Query("1d")):
             "interval": interval,
             "series": out,
         }
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+RANGE_TO_DAYS = {"1w": 7, "1m": 30, "3m": 90, "6m": 180, "9m": 270, "1y": 365}
+
+
+@app.get("/news/{ticker}")
+def news(
+    ticker: str,
+    range: str = Query("1w", pattern="^(1w|1m|3m|6m|9m|1y)$"),
+    max_items: int = 25,
+    analyze: bool = True,
+):
+    try:
+        days = RANGE_TO_DAYS.get(range, 7)
+
+        # Try to get company name to improve query
+        name = None
+        try:
+            info = (yf.Ticker(ticker.upper()).get_info() or yf.Ticker(ticker.upper()).info)
+            name = info.get("shortName") or info.get("longName")
+        except Exception:
+            pass
+
+        query = f"{name or ticker} OR {ticker} stock"
+        url = (
+            "https://news.google.com/rss/search?"
+            f"q={quote_plus(query + ' when:' + str(days) + 'd')}"
+            "&hl=en-US&gl=US&ceid=US:en"
+        )
+
+        feed = feedparser.parse(url)
+        if feed.bozo:
+            raise HTTPException(status_code=503, detail="Failed to parse feed")
+
+        items = []
+        for entry in feed.entries[:max_items]:
+            link = _unwrap_google_news(entry.get("link", ""))
+            src = getattr(entry, "source", None)
+            source_name = getattr(src, "title", None) if src else None
+            published = (
+                time.strftime("%Y-%m-%dT%H:%M:%SZ", entry.published_parsed)
+                if getattr(entry, "published_parsed", None)
+                else None
+            )
+            items.append(
+                {
+                    "title": entry.get("title", ""),
+                    "link": link,
+                    "source": source_name,
+                    "published": published,
+                }
+            )
+
+        if analyze and items:
+            sentiments = classify_texts_via_api([it["title"] for it in items])
+            for it, s in zip(items, sentiments):
+                it.update(
+                    {
+                        "sentiment": s["sentiment"],
+                        "confidence": s["confidence"],
+                        "stars": s["stars"],
+                    }
+                )
+
+        return {"ticker": ticker.upper(), "range": range, "count": len(items), "items": items}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=503, detail=str(e))
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,5 @@ scikit-learn
 tensorflow==2.20.0
 pandas-market-calendars
 matplotlib
+feedparser
+requests

--- a/frontend/app/t/[ticker]/page.jsx
+++ b/frontend/app/t/[ticker]/page.jsx
@@ -18,6 +18,10 @@ const BacktestPanel = dynamic(
   () => import("@/components/stock/backtest-panel").then((m) => m.BacktestPanel),
   { ssr: false }
 );
+const NewsPanel = dynamic(
+  () => import("@/components/stock/news-panel"),
+  { ssr: false }
+);
 
 export default function TickerPage() {
   const params = useParams()
@@ -77,7 +81,7 @@ export default function TickerPage() {
               </div>
             )}
 
-            {activeTab === 'news' && <LatestHeadlines ticker={ticker} limit={8} />}
+            {activeTab === 'news' && <NewsPanel ticker={ticker} />}
 
             {activeTab === 'predictions' && (
               <Suspense

--- a/frontend/components/stock/news-panel.jsx
+++ b/frontend/components/stock/news-panel.jsx
@@ -1,0 +1,110 @@
+"use client";
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+const RANGES = [
+  { label: "1W", value: "1w" },
+  { label: "1M", value: "1m" },
+  { label: "3M", value: "3m" },
+  { label: "6M", value: "6m" },
+  { label: "9M", value: "9m" },
+  { label: "1Y", value: "1y" },
+];
+
+function SentimentPill({ s }) {
+  const base = "px-2 py-0.5 rounded-full text-xs";
+  if (s === "positive")
+    return <span className={`${base} bg-green-600/20 text-green-400`}>positive</span>;
+  if (s === "negative")
+    return <span className={`${base} bg-red-600/20 text-red-400`}>negative</span>;
+  return <span className={`${base} bg-zinc-600/20 text-zinc-300`}>neutral</span>;
+}
+
+export default function NewsPanel({ ticker }) {
+  const [range, setRange] = useState("1w");
+  const [data, setData] = useState(null);
+  const [err, setErr] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  async function load() {
+    try {
+      setLoading(true);
+      setErr(null);
+      const json = await api(`/news/${ticker}?range=${range}&analyze=1`);
+      setData(json);
+    } catch (e) {
+      setErr(e);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (ticker) load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ticker, range]);
+
+  return (
+    <div className="space-y-4 text-zinc-900 dark:text-zinc-100">
+      <div className="flex gap-2 flex-wrap">
+        {RANGES.map((r) => (
+          <button
+            key={r.value}
+            onClick={() => setRange(r.value)}
+            className={`px-3 py-1 rounded border border-zinc-700/40 ${
+              range === r.value ? "bg-zinc-900 text-white" : "bg-transparent"
+            }`}
+          >
+            {r.label}
+          </button>
+        ))}
+        <button
+          onClick={load}
+          className="ml-auto px-3 py-1 rounded border border-zinc-700/40"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading && <div className="text-sm opacity-70">Loading news…</div>}
+      {err && (
+        <div className="text-sm text-red-500">
+          Failed: {String(err.message || err)}
+        </div>
+      )}
+      {!loading && !err && (!data || data.items?.length === 0) && (
+        <div className="text-sm opacity-70">No recent articles.</div>
+      )}
+
+      {data?.items?.length > 0 && (
+        <ul className="space-y-3">
+          {data.items.map((it, i) => (
+            <li
+              key={i}
+              className="rounded border border-zinc-800/40 p-3 bg-white/50 dark:bg-zinc-900/30"
+            >
+              <div className="text-xs flex items-center gap-2">
+                <SentimentPill s={it.sentiment} />
+                {it.source && <span className="opacity-70">{it.source}</span>}
+                {it.published && (
+                  <span className="opacity-60">
+                    • {new Date(it.published).toLocaleString()}
+                  </span>
+                )}
+              </div>
+              <a
+                href={it.link}
+                target="_blank"
+                rel="noreferrer"
+                className="block mt-1 hover:underline"
+              >
+                {it.title || "(untitled)"}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement `/news/{ticker}` backend route that scrapes Google News, optional sentiment via HF API
- add NewsPanel React component with range selector and sentiment chips
- wire News tab to use new NewsPanel

## Testing
- `pip install feedparser requests` *(failed: Tunnel connection failed 403)*
- `python -m py_compile backend/app.py`
- `npm run lint` *(interactive prompt, unable to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b074a2c483329119f70f87abe806