### PR TITLE
Add LSTM backtesting API and frontend integration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 
 from app.core.config import make_app, logger
-from app.routes import forecast, overview, chart, extract, news, filings
+from app.routes import forecast, overview, chart, extract, news, filings, backtest
 from app.services.sentiment import preload
 
 app = make_app()
@@ -13,6 +13,7 @@ app.include_router(chart.router)
 app.include_router(extract.router)
 app.include_router(news.router)
 app.include_router(filings.router)
+app.include_router(backtest.router)
 
 
 @app.on_event("startup")

--- a/backend/app/routes/backtest.py
+++ b/backend/app/routes/backtest.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, HTTPException, Query
+from app.schemas import BacktestOut
+from app.services.backtest import run_backtest
+
+router = APIRouter()
+
+@router.get("/backtest", response_model=BacktestOut)
+def backtest(
+    ticker: str = Query(..., description="e.g. AAPL"),
+    look_back: int = Query(60, ge=10, le=365),
+    horizon: int = Query(10, ge=1, le=60),
+    start: str = Query("2018-01-01"),
+    end: str | None = Query(None),
+):
+    try:
+        return run_backtest(ticker.upper(), look_back, horizon, start, end)
+    except Exception as e:
+        raise HTTPException(500, f"Backtest failed: {e}")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -12,3 +12,23 @@ class ForecastOut(BaseModel):
     look_back: int
     horizon: int
     forecast: list
+
+class BacktestPoint(BaseModel):
+    date: str
+    pred: float
+    actual: float
+
+
+class BacktestMetrics(BaseModel):
+    rmse: float
+    mape: float
+    sharpe: float
+    cumulative_return: float
+
+
+class BacktestOut(BaseModel):
+    ticker: str
+    look_back: int
+    horizon: int
+    metrics: BacktestMetrics
+    results: list[BacktestPoint]

--- a/backend/app/services/backtest.py
+++ b/backend/app/services/backtest.py
@@ -1,0 +1,202 @@
+import numpy as np
+import pandas as pd
+import yfinance as yf
+from sklearn.preprocessing import StandardScaler
+from sklearn.metrics import mean_squared_error, mean_absolute_percentage_error
+import tensorflow as tf
+
+# --- helpers copied from notebook ---
+
+def fetch_prices(ticker: str, start="2016-01-01", end=None, interval="1d") -> pd.DataFrame:
+    df = yf.download(ticker, start=start, end=end, interval=interval, auto_adjust=True, progress=False)
+    if df.empty:
+        raise ValueError("No data returned. Check ticker/interval or your network.")
+    df.index.name = "Date"
+    return df[["Open", "High", "Low", "Close", "Volume"]].dropna()
+
+
+def add_features(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy()
+    close = pd.to_numeric(out["Close"].squeeze(), errors="coerce")
+    close = close.where(close > 0, np.nan)
+    out["Close"] = close
+
+    # base returns
+    out["log_ret"] = np.log(close).diff()
+    out["ret"] = close.pct_change()
+
+    # rolling stats
+    out["roll_mean_7"] = close.rolling(7).mean()
+    out["roll_std_7"] = close.rolling(7).std()
+    out["roll_mean_21"] = close.rolling(21).mean()
+    out["roll_std_21"] = close.rolling(21).std()
+
+    # RSI(14)
+    delta = close.diff()
+    up = delta.clip(lower=0)
+    down = -delta.clip(upper=0)
+    roll_up = up.ewm(alpha=1 / 14, min_periods=14, adjust=False).mean()
+    roll_dn = down.ewm(alpha=1 / 14, min_periods=14, adjust=False).mean()
+    rs = roll_up / roll_dn.replace(0, np.nan)
+    out["rsi_14"] = 100 - (100 / (1 + rs))
+
+    # MACD (12,26,9)
+    ema12 = close.ewm(span=12, adjust=False).mean()
+    ema26 = close.ewm(span=26, adjust=False).mean()
+    macd = ema12 - ema26
+    out["macd"] = macd
+    out["macd_signal"] = macd.ewm(span=9, adjust=False).mean()
+    out["macd_diff"] = out["macd"] - out["macd_signal"]
+
+    # Bollinger width (20,2)
+    ma20 = close.rolling(20).mean()
+    sd20 = close.rolling(20).std()
+    out["bb_width"] = (ma20 + 2 * sd20 - (ma20 - 2 * sd20)) / close
+
+    # lags & volatility
+    out["ret_lag1"] = out["log_ret"].shift(1)
+    out["ret_lag3"] = out["log_ret"].shift(3)
+    out["ret_lag5"] = out["log_ret"].shift(5)
+    out["vol_7"] = out["log_ret"].rolling(7).std()
+    out["vol_21"] = out["log_ret"].rolling(21).std()
+    out["z_close_21"] = (close - close.rolling(21).mean()) / close.rolling(21).std()
+
+    return out.dropna()
+
+
+FEATURES = [
+    "Close",
+    "Volume",
+    "log_ret",
+    "ret",
+    "roll_mean_7",
+    "roll_std_7",
+    "roll_mean_21",
+    "roll_std_21",
+    "rsi_14",
+    "macd",
+    "macd_signal",
+    "macd_diff",
+    "bb_width",
+    "ret_lag1",
+    "ret_lag3",
+    "ret_lag5",
+    "vol_7",
+    "vol_21",
+    "z_close_21",
+]
+
+
+def make_windows(X: np.ndarray, y: np.ndarray, lookback: int, horizon: int):
+    xs, ys = [], []
+    for i in range(lookback, len(X) - horizon + 1):
+        xs.append(X[i - lookback : i, :])
+        ys.append(y[i : i + horizon])
+    return np.array(xs, dtype="float32"), np.array(ys, dtype="float32")
+
+
+def build_model(input_steps: int, n_features: int, horizon: int) -> tf.keras.Model:
+    inp = tf.keras.Input(shape=(input_steps, n_features))
+    x = tf.keras.layers.Conv1D(48, kernel_size=5, padding="causal", activation="relu")(inp)
+    x = tf.keras.layers.Dropout(0.2)(x)
+    x = tf.keras.layers.Bidirectional(tf.keras.layers.LSTM(160, return_sequences=True))(x)
+    x = tf.keras.layers.Dropout(0.3)(x)
+    x = tf.keras.layers.LSTM(96)(x)
+    out = tf.keras.layers.Dense(horizon)(x)
+    model = tf.keras.Model(inp, out)
+    model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=1e-3), loss="mse")
+    return model
+
+
+def run_backtest(ticker: str, look_back: int, horizon: int, start_date: str, end_date: str | None = None):
+    raw = fetch_prices(ticker, start=start_date, end=end_date)
+    df = add_features(raw)
+    df["target_ret"] = df["log_ret"].shift(-1)
+    df = df.dropna()
+
+    X_df = df[FEATURES].astype("float32")
+    y = df["target_ret"].astype("float32").values
+    dates = df.index
+
+    results: list[dict] = []
+    preds: list[float] = []
+    actuals: list[float] = []
+    strategy_returns: list[float] = []
+
+    max_windows = 50
+    start_idx = look_back
+    while start_idx + horizon <= len(df) and len(results) / horizon < max_windows:
+        train_X_df = X_df.iloc[:start_idx]
+        train_y = y[:start_idx]
+
+        scaler_X = StandardScaler()
+        X_train = scaler_X.fit_transform(train_X_df.values)
+        scaler_y = StandardScaler()
+        y_train_s = scaler_y.fit_transform(train_y.reshape(-1, 1)).ravel()
+
+        X_train_w, y_train_w = make_windows(X_train, y_train_s, look_back, horizon)
+        if len(X_train_w) == 0:
+            break
+        model = build_model(look_back, X_train_w.shape[2], horizon)
+        cbs = [
+            tf.keras.callbacks.EarlyStopping(monitor="loss", patience=5, restore_best_weights=True)
+        ]
+        model.fit(
+            X_train_w,
+            y_train_w,
+            epochs=20,
+            batch_size=32,
+            verbose=0,
+            callbacks=cbs,
+        )
+
+        last_block_raw = train_X_df.values[-look_back:]
+        last_block = scaler_X.transform(last_block_raw).reshape(1, look_back, X_train_w.shape[2])
+        next_ret_s = model.predict(last_block, verbose=0)[0]
+        next_ret = scaler_y.inverse_transform(next_ret_s.reshape(-1, 1)).ravel()
+
+        last_price = df["Close"].iloc[start_idx - 1]
+        pred_prices = last_price * np.exp(np.cumsum(next_ret))
+        actual_prices = df["Close"].iloc[start_idx : start_idx + horizon].values
+
+        prev_price = last_price
+        for j in range(min(horizon, len(actual_prices))):
+            date = dates[start_idx + j].strftime("%Y-%m-%d")
+            pred_price = float(pred_prices[j])
+            actual_price = float(actual_prices[j])
+            results.append({"date": date, "pred": pred_price, "actual": actual_price})
+            preds.append(pred_price)
+            actuals.append(actual_price)
+            if j == 0:
+                actual_return = (actual_price - prev_price) / prev_price
+                pred_return = (pred_price - prev_price) / prev_price
+                strategy_returns.append(np.sign(pred_return) * actual_return)
+        start_idx += horizon
+
+    if not results:
+        raise ValueError("Not enough data for backtest")
+
+    y_true = np.array(actuals)
+    y_pred = np.array(preds)
+    rmse = float(np.sqrt(mean_squared_error(y_true, y_pred)))
+    mape = float(mean_absolute_percentage_error(y_true, y_pred) * 100)
+    if strategy_returns:
+        sr_arr = np.array(strategy_returns)
+        sharpe = float(sr_arr.mean() / (sr_arr.std() + 1e-8) * np.sqrt(252))
+        cumulative_return = float(np.prod(1 + sr_arr) - 1)
+    else:
+        sharpe = 0.0
+        cumulative_return = 0.0
+
+    return {
+        "ticker": ticker.upper(),
+        "look_back": look_back,
+        "horizon": horizon,
+        "metrics": {
+            "rmse": rmse,
+            "mape": mape,
+            "sharpe": sharpe,
+            "cumulative_return": cumulative_return,
+        },
+        "results": results,
+    }

--- a/backend/notebooks/Backtest_LSTM.ipynb
+++ b/backend/notebooks/Backtest_LSTM.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4fce3a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# parameters\n",
+    "TICKER = globals().get('TICKER','AAPL')\n",
+    "LOOKBACK = globals().get('LOOKBACK',60)\n",
+    "HORIZON = globals().get('HORIZON',10)\n",
+    "START_DATE = globals().get('START_DATE','2018-01-01')\n",
+    "END_DATE = globals().get('END_DATE',None)\n",
+    "OUTPUT_JSON = globals().get('OUTPUT_JSON','backtest.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11c45b51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from app.services.backtest import run_backtest\n",
+    "res = run_backtest(TICKER, LOOKBACK, HORIZON, START_DATE, END_DATE)\n",
+    "import json\n",
+    "with open(OUTPUT_JSON,'w') as f:\n",
+    "    json.dump(res,f)\n",
+    "res"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/frontend/components/stock/tabs/backtest-tab.jsx
+++ b/frontend/components/stock/tabs/backtest-tab.jsx
@@ -1,218 +1,152 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { TrendingUp, BarChart3, Target } from "lucide-react"
+import { useState } from "react"
+import { BarChart3 } from "lucide-react"
 import { MetricBox } from "@/components/stock/metric-box"
 import { ChartWrapper } from "@/components/stock/chart-wrapper"
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts"
+import { api } from "@/lib/api"
 
 export function BacktestTab({ ticker }) {
-  const [backtestData, setBacktestData] = useState([])
-  const [loading, setLoading] = useState(true)
+  const [lookBack, setLookBack] = useState(60)
+  const [horizon, setHorizon] = useState(10)
+  const [start, setStart] = useState("2020-01-01")
+  const [end, setEnd] = useState("")
+  const [result, setResult] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [err, setErr] = useState(null)
 
-  useEffect(() => {
-    // Mock backtest data generation
-    const generateBacktestData = () => {
-      const data = []
-      let portfolioValue = 10000
-      let benchmark = 10000
-
-      for (let i = 0; i < 252; i++) {
-        // 1 year of trading days
-        const strategyReturn = (Math.random() - 0.45) * 0.02 // Slightly positive bias
-        const benchmarkReturn = (Math.random() - 0.48) * 0.015 // Market return
-
-        portfolioValue *= 1 + strategyReturn
-        benchmark *= 1 + benchmarkReturn
-
-        data.push({
-          date: new Date(Date.now() - (251 - i) * 24 * 60 * 60 * 1000).toLocaleDateString(),
-          portfolio: portfolioValue,
-          benchmark: benchmark,
-          drawdown: Math.min(
-            0,
-            (portfolioValue / Math.max(...data.map((d) => d?.portfolio || portfolioValue)) - 1) * 100,
-          ),
-        })
-      }
-
-      return data
-    }
-
-    setTimeout(() => {
-      setBacktestData(generateBacktestData())
+  async function run(e) {
+    e.preventDefault()
+    if (!ticker) return
+    setLoading(true)
+    setErr(null)
+    try {
+      const params = new URLSearchParams({
+        ticker,
+        look_back: String(lookBack),
+        horizon: String(horizon),
+        start,
+      })
+      if (end) params.append("end", end)
+      const res = await api(`/backtest?${params.toString()}`)
+      setResult(res)
+    } catch (e) {
+      setErr(e)
+      setResult(null)
+    } finally {
       setLoading(false)
-    }, 800)
-  }, [ticker])
-
-  const calculateMetrics = () => {
-    if (backtestData.length === 0) return {}
-
-    const finalValue = backtestData[backtestData.length - 1].portfolio
-    const totalReturn = ((finalValue - 10000) / 10000) * 100
-
-    const returns = backtestData.map((d, i) => (i === 0 ? 0 : d.portfolio / backtestData[i - 1].portfolio - 1)).slice(1)
-
-    const avgReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length
-    const riskLevel =
-      Math.sqrt(returns.reduce((sum, r) => sum + Math.pow(r - avgReturn, 2), 0) / returns.length) * Math.sqrt(252) * 100
-
-    const riskAdjustedReturn = (avgReturn * 252) / (riskLevel / 100)
-    const maxDrawdown = Math.min(...backtestData.map((d) => d.drawdown))
-
-    return {
-      totalReturn: totalReturn.toFixed(2),
-      riskAdjustedReturn: riskAdjustedReturn.toFixed(2),
-      riskLevel: riskLevel.toFixed(2),
-      maxDrawdown: Math.abs(maxDrawdown).toFixed(2),
     }
   }
 
-  const metrics = calculateMetrics()
-
-  const performanceMetrics = [
-    {
-      label: "Total Return",
-      value: metrics.totalReturn || "0",
-      format: "percentage",
-      change: Number.parseFloat(metrics.totalReturn || "0"),
-      tooltip: "Total profit or loss from the strategy",
-    },
-    {
-      label: "Risk-Adjusted Return",
-      value: metrics.riskAdjustedReturn || "0",
-      format: "number",
-      tooltip: "How much return you get for the risk taken",
-    },
-    {
-      label: "Risk Level",
-      value: metrics.riskLevel || "0",
-      format: "percentage",
-      tooltip: "How much the strategy's returns typically vary",
-    },
-    {
-      label: "Largest Drop",
-      value: metrics.maxDrawdown || "0",
-      format: "percentage",
-      tooltip: "The biggest decline from peak to trough",
-    },
-  ]
+  const metrics = result?.metrics || {}
+  const data = result?.results || []
 
   return (
-    <div className="space-y-6">
-      {/* Performance Metrics */}
-      <div>
-        <h3 className="text-lg font-poppins font-semibold mb-4 flex items-center gap-2 text-white">
-          <BarChart3 className="size-5 text-primary" />
-          Backtest Results
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          {performanceMetrics.map((metric) => (
-            <MetricBox
-              key={metric.label}
-              label={metric.label}
-              value={metric.value}
-              format={metric.format}
-              change={metric.change}
-              tooltip={metric.tooltip}
-              animate={true}
-            />
-          ))}
-        </div>
-      </div>
-
-      {/* Equity Curve */}
-      <ChartWrapper title="Strategy Performance vs Market" loading={loading}>
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={backtestData}>
-            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-            <XAxis dataKey="date" stroke="hsl(var(--muted-foreground))" fontSize={12} />
-            <YAxis
-              stroke="hsl(var(--muted-foreground))"
-              fontSize={12}
-              tickFormatter={(value) => `$${(value / 1000).toFixed(0)}K`}
-            />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: "hsl(var(--card))",
-                border: "1px solid hsl(var(--border))",
-                borderRadius: "8px",
-              }}
-              formatter={(value, name) => [`$${value.toLocaleString()}`, name === "portfolio" ? "Strategy" : "Market"]}
-            />
-            <Line
-              type="monotone"
-              dataKey="portfolio"
-              stroke="hsl(var(--primary))"
-              strokeWidth={2}
-              dot={false}
-              name="Strategy"
-            />
-            <Line
-              type="monotone"
-              dataKey="benchmark"
-              stroke="hsl(var(--muted-foreground))"
-              strokeWidth={2}
-              strokeDasharray="5 5"
-              dot={false}
-              name="Market"
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </ChartWrapper>
-
-      {/* Strategy Details */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="space-y-4">
-          <h4 className="font-poppins font-semibold flex items-center gap-2 text-white">
-            <Target className="size-4 text-primary" />
-            Strategy Details
-          </h4>
-          <div className="space-y-3 text-sm">
-            <div className="flex justify-between">
-              <span className="text-muted">Model Type:</span>
-              <span className="text-white">AI Neural Network</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-muted">Training Period:</span>
-              <span className="text-white">2 Years</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-muted">Rebalancing:</span>
-              <span className="text-white">Daily</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-muted">Transaction Costs:</span>
-              <span className="text-white">0.1%</span>
+    <div className="space-y-6 relative">
+      {loading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/40">
+          <div className="w-48">
+            <div className="h-2 bg-muted rounded">
+              <div className="h-full w-3/4 animate-pulse bg-primary rounded" />
             </div>
           </div>
         </div>
+      )}
 
-        <div className="space-y-4">
-          <h4 className="font-poppins font-semibold flex items-center gap-2 text-white">
-            <TrendingUp className="size-4 text-success" />
-            Risk Metrics
-          </h4>
-          <div className="space-y-3 text-sm">
-            <div className="flex justify-between">
-              <span className="text-muted">Market Sensitivity:</span>
-              <span className="text-white">0.85</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-muted">Excess Return:</span>
-              <span className="text-success">+2.3%</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-muted">Win Rate:</span>
-              <span className="text-white">58.2%</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-muted">Average Win/Loss:</span>
-              <span className="text-white">1.4x</span>
+      <form onSubmit={run} className="flex flex-wrap items-end gap-2 text-sm">
+        <div className="flex flex-col">
+          <label>Look Back</label>
+          <input
+            type="number"
+            value={lookBack}
+            onChange={(e) => setLookBack(Number(e.target.value))}
+            className="px-2 py-1 rounded border bg-background"
+          />
+        </div>
+        <div className="flex flex-col">
+          <label>Horizon</label>
+          <input
+            type="number"
+            value={horizon}
+            onChange={(e) => setHorizon(Number(e.target.value))}
+            className="px-2 py-1 rounded border bg-background"
+          />
+        </div>
+        <div className="flex flex-col">
+          <label>Start</label>
+          <input
+            type="date"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+            className="px-2 py-1 rounded border bg-background"
+          />
+        </div>
+        <div className="flex flex-col">
+          <label>End</label>
+          <input
+            type="date"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+            className="px-2 py-1 rounded border bg-background"
+          />
+        </div>
+        <button type="submit" className="px-4 py-2 rounded bg-primary text-primary-foreground">
+          Run Backtest
+        </button>
+      </form>
+
+      {!result && !loading && (
+        <div className="text-sm text-muted-foreground">No backtest yet, select parameters to run one.</div>
+      )}
+
+      {err && <div className="text-sm text-red-500">{String(err.message || err)}</div>}
+
+      {result && (
+        <>
+          <div>
+            <h3 className="text-lg font-poppins font-semibold mb-4 flex items-center gap-2 text-white">
+              <BarChart3 className="size-5 text-primary" />
+              Backtest Results
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              <MetricBox label="RMSE" value={metrics.rmse?.toFixed?.(2) ?? "0"} format="number" />
+              <MetricBox label="MAPE" value={metrics.mape?.toFixed?.(2) ?? "0"} format="number" />
+              <MetricBox label="Sharpe" value={metrics.sharpe?.toFixed?.(2) ?? "0"} format="number" />
+              <MetricBox
+                label="Cumulative Return"
+                value={metrics.cumulative_return ? (metrics.cumulative_return * 100).toFixed(2) : "0"}
+                format="percentage"
+              />
             </div>
           </div>
-        </div>
-      </div>
+
+          <ChartWrapper title="Predicted vs Actual" loading={false}>
+            <ResponsiveContainer width="100%" height={400}>
+              <LineChart data={data}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="date" stroke="hsl(var(--muted-foreground))" fontSize={12} />
+                <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "hsl(var(--card))",
+                    border: "1px solid hsl(var(--border))",
+                    borderRadius: "8px",
+                  }}
+                />
+                <Line type="monotone" dataKey="actual" stroke="hsl(var(--primary))" strokeWidth={2} dot={false} />
+                <Line
+                  type="monotone"
+                  dataKey="pred"
+                  stroke="hsl(var(--muted-foreground))"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartWrapper>
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add reusable LSTM backtesting service with sliding window evaluation and metrics
- expose `/backtest` FastAPI endpoint
- add front-end Backtest tab to run backtests and visualize predictions vs actuals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a77f1165e88332964d3293f4208e75