### PR TITLE
Improve prediction chart visibility and KPIs

### DIFF
--- a/frontend/components/stock/PredictionChart.jsx
+++ b/frontend/components/stock/PredictionChart.jsx
@@ -1,33 +1,108 @@
 "use client";
 import { useTheme } from "next-themes";
-import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from "recharts";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
 
 export default function PredictionChart({ data }) {
   const { theme } = useTheme();
   const axisColor = theme === "dark" ? "#fff" : "hsl(var(--foreground))";
   const tooltipBg = theme === "dark" ? "rgba(0,0,0,0.9)" : "rgba(255,255,255,0.98)";
 
-  // Compute Y domain with a small pad
-  const prices = (data || []).flatMap(d => [d.actual, d.pred]).filter(v => Number.isFinite(v));
-  const lo = prices.length ? Math.min(...prices) : 0;
-  const hi = prices.length ? Math.max(...prices) : 1;
-  const pad = Math.max((hi - lo) * 0.02, 0.5);
-  const domain = [lo - pad, hi + pad];
+  const prices = (data || [])
+    .flatMap((d) => [d.actual, d.pred])
+    .filter((v) => Number.isFinite(v));
+  const max = prices.length ? Math.max(...prices) : 0;
+  const step = max >= 1000 ? 1000 : 100;
+  const maxRounded = Math.ceil(max / step) * step || step;
+  const yTicks = Array.from({ length: 4 }, (_, i) => ((i + 1) * maxRounded) / 4);
+
+  const dates = (data || []).map((d) => d.date);
+  const xTicks = (() => {
+    if (dates.length === 0) return [];
+    const ticks = [];
+    const start = new Date(dates[0]);
+    const end = new Date(dates[dates.length - 1]);
+    const dt = new Date(start);
+    dt.setDate(1);
+    while (dt <= end) {
+      ticks.push(dt.toISOString().slice(0, 10));
+      dt.setMonth(dt.getMonth() + 4);
+    }
+    return ticks;
+  })();
+
+  const fmtCurrency = (v) => `$${v.toFixed(2)}`;
+
+  const renderTooltip = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      const row = payload[0].payload;
+      return (
+        <div
+          style={{
+            backgroundColor: tooltipBg,
+            border: "1px solid hsl(var(--border))",
+            padding: "0.5rem",
+          }}
+        >
+          <div>Date: {label}</div>
+          <div>
+            Predicted: {row.pred !== undefined ? fmtCurrency(row.pred) : "N/A"}
+          </div>
+          <div>
+            Actual: {row.actual !== undefined ? fmtCurrency(row.actual) : "N/A"}
+          </div>
+          <div>
+            Accuracy: {row.accuracy != null ? `${row.accuracy.toFixed(1)}%` : "N/A"}
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
 
   return (
     <ResponsiveContainer width="100%" height={340}>
-      <LineChart data={data || []} margin={{ top: 24, right: 24, bottom: 24, left: 48 }}>
+      <LineChart data={data || []} margin={{ top: 24, right: 24, bottom: 80, left: 48 }}>
         <CartesianGrid strokeOpacity={0.12} stroke="hsl(var(--border))" />
-        <XAxis dataKey="date" tick={{ fill: axisColor }} interval="preserveStartEnd" />
-        <YAxis domain={domain} tick={{ fill: axisColor }} />
-        <Tooltip
-          contentStyle={{ backgroundColor: tooltipBg, border: "1px solid hsl(var(--border))" }}
-          formatter={(v, name) => [`$${Number(v).toFixed(2)}`, name === "actual" ? "Actual" : "Predicted"]}
+        <XAxis
+          dataKey="date"
+          ticks={xTicks}
+          tick={{ fill: axisColor }}
+          angle={-45}
+          textAnchor="end"
+          height={80}
         />
-        {/* actual */}
-        <Line dataKey="actual" stroke="hsl(var(--chart-line, var(--primary)))" dot={false} strokeWidth={2} />
-        {/* predicted */}
-        <Line dataKey="pred" stroke="#f97316" dot={false} strokeWidth={2} />
+        <YAxis
+          domain={[0, maxRounded]}
+          ticks={yTicks}
+          tick={{ fill: axisColor }}
+          tickFormatter={(v) => `$${v}`}
+        />
+        <Tooltip content={renderTooltip} />
+        <Legend />
+        <Line
+          dataKey="actual"
+          name="Actual"
+          stroke="#2563eb"
+          dot={false}
+          strokeWidth={2}
+        />
+        <Line
+          dataKey="pred"
+          name="Predicted"
+          stroke="#f97316"
+          dot={{ r: 3 }}
+          activeDot={{ r: 5 }}
+          strokeWidth={2}
+        />
       </LineChart>
     </ResponsiveContainer>
   );

--- a/frontend/components/stock/prediction-panel.jsx
+++ b/frontend/components/stock/prediction-panel.jsx
@@ -6,6 +6,7 @@ import { MetricBox } from "@/components/stock/metric-box";
 import { ChartWrapper } from "@/components/stock/chart-wrapper";
 import DayRange from "@/components/stock/DayRange";
 import PredictionChart from "./PredictionChart";
+import { StatCard } from "@/components/stock/stat-card";
 import { usePrediction } from "./use-prediction-hook";
 
 export default function PredictionPanel({ ticker }) {
@@ -17,8 +18,44 @@ export default function PredictionPanel({ ticker }) {
   const { state, result, err } = usePrediction(ticker, { lookBack, context, backtestHorizon, horizon });
   const loading = state === "loading";
 
-  const series = useMemo(() => result?.forecast || [], [result]);
   const metrics = result?.metrics || {};
+  const series = useMemo(() => {
+    const raw = result?.forecast || [];
+    return raw.map((r) => {
+      let accuracy = null;
+      if (Number.isFinite(r.pred) && Number.isFinite(r.actual)) {
+        const denom = r.actual === 0 ? 1 : r.actual;
+        const pctErr = Math.abs((r.pred - r.actual) / denom) * 100;
+        accuracy = 100 - pctErr;
+      }
+      return { ...r, accuracy };
+    });
+  }, [result]);
+
+  const backtestRows = useMemo(
+    () => series.filter((r) => r.part === "backtest" && r.accuracy !== null),
+    [series]
+  );
+  const avgAbsErr =
+    backtestRows.length > 0
+      ? backtestRows.reduce((s, r) => s + Math.abs(r.pred - r.actual), 0) /
+        backtestRows.length
+      : 0;
+  const meanPctErr =
+    backtestRows.length > 0
+      ?
+          backtestRows.reduce(
+            (s, r) =>
+              s +
+              Math.abs(
+                (r.pred - r.actual) / (r.actual === 0 ? 1 : r.actual)
+              ) * 100,
+            0
+          ) /
+        backtestRows.length
+      : 0;
+  const avgAccuracy = backtestRows.length > 0 ? 100 - meanPctErr : 0;
+  const directionalAcc = metrics.accuracy_pct || 0;
 
   return (
     <div className="space-y-6 relative">
@@ -42,16 +79,29 @@ export default function PredictionPanel({ ticker }) {
       {result && (
         <div className="space-y-6" aria-live="polite">
           {/* Friendly KPIs for general users */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <MetricBox label="Accuracy (direction)" value={(metrics.accuracy_pct || 0).toFixed(1)} format="percentage" />
-            <MetricBox label="MAPE (backtest)" value={(metrics.mape || 0).toFixed(2)} format="percentage" />
-            <MetricBox label="Expected 10-day move" value={(metrics.expected_10d_move_pct || 0).toFixed(2)} format="percentage" />
-            <MetricBox label="RMSE (backtest)" value={(metrics.rmse || 0).toFixed(2)} format="number" />
+          <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-3 gap-4">
+            <MetricBox
+              label="Avg 20-day Accuracy"
+              value={avgAccuracy.toFixed(1)}
+              format="percentage"
+            />
+            <MetricBox
+              label="Average Absolute Error"
+              value={Number(avgAbsErr.toFixed(2))}
+              format="currency"
+            />
+            <MetricBox
+              label="Mean % Error"
+              value={meanPctErr.toFixed(2)}
+              format="percentage"
+            />
           </div>
 
           <Card className="p-4">
             <div className="flex items-center justify-between mb-3">
-              <div className="font-heading font-medium">Last {context} days + backtest {backtestHorizon}d + forecast {horizon}d</div>
+              <div className="font-heading font-medium">
+                Last {context} days + backtest {backtestHorizon}d + forecast {horizon}d
+              </div>
               <DayRange disabled value={context} />
             </div>
             <ChartWrapper title="">
@@ -59,6 +109,18 @@ export default function PredictionPanel({ ticker }) {
             </ChartWrapper>
             <div className="text-xs text-muted-foreground mt-3">
               Orange = model prediction; Blue = actual. “Backtest” segment shows one-step predictions on the last {backtestHorizon} sessions.
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+              <StatCard
+                title="Typical prediction error"
+                value={`$${avgAbsErr.toFixed(2)}`}
+                description="over last 20 days"
+              />
+              <StatCard
+                title="Directional accuracy"
+                value={`${directionalAcc.toFixed(1)}%`}
+                description="over last 20 days"
+              />
             </div>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- Show full prediction and actual price lines with legend, accuracy tooltips, and rounded axes
- Add intuitive KPI cards highlighting accuracy and error metrics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ab8c24088332bdad8a5db9600349